### PR TITLE
articleLookTask.save()单独启动线程，防止阻塞主线程

### DIFF
--- a/blog-web/src/main/java/com/zyd/blog/runner/TaskRunner.java
+++ b/blog-web/src/main/java/com/zyd/blog/runner/TaskRunner.java
@@ -1,10 +1,13 @@
 package com.zyd.blog.runner;
 
+import cn.hutool.core.thread.ThreadFactoryBuilder;
 import com.zyd.blog.core.schedule.ArticleLookTask;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.stereotype.Component;
+
+import java.util.concurrent.*;
 
 /**
  * 执行保存文章浏览记录任务
@@ -20,6 +23,14 @@ public class TaskRunner implements ApplicationRunner {
 
     @Override
     public void run(ApplicationArguments args) {
-        articleLookTask.save();
+        ThreadFactory articleLookThreadFactory = new ThreadFactoryBuilder().setNamePrefix("BLOG-ARTICLE_LOOK-").build();
+
+        ExecutorService singleThreadPool = new ThreadPoolExecutor(1, 1,
+                3650L, TimeUnit.DAYS,
+                new LinkedBlockingQueue<Runnable>(1024),
+                articleLookThreadFactory, new ThreadPoolExecutor.AbortPolicy());
+
+        singleThreadPool.execute(()-> articleLookTask.save());
+        singleThreadPool.shutdown();
     }
 }


### PR DESCRIPTION
ArticleLookTask.save()方法中使用的是BlockingQueue，会阻塞当前线程。同时，该方法的接入为ApplicationRunner, ApplicationRunner是单线程模式，这样就可能会出现，当前线程一直卡死在这里（TaskRunner），其他后续的ApplicationRunner也无法执行，且不报错，而系统一直无法启动。