### PR TITLE
Fix Critical Password Security Vulnerability in Password Update

### DIFF
--- a/blog-core/src/main/java/com/zyd/blog/business/service/impl/SysUserServiceImpl.java
+++ b/blog-core/src/main/java/com/zyd/blog/business/service/impl/SysUserServiceImpl.java
@@ -204,7 +204,9 @@ public class SysUserServiceImpl implements SysUserService {
         if (!user.getPassword().equals(PasswordUtil.encrypt(userPwd.getPassword(), user.getUsername()))) {
             throw new ZhydException("原密码不正确！");
         }
-        user.setPassword(userPwd.getNewPassword());
+        
+        // Fix: Encrypt the new password before storing it
+        user.setPassword(PasswordUtil.encrypt(userPwd.getNewPassword(), user.getUsername()));
 
         return this.updateSelective(user);
     }


### PR DESCRIPTION
This PR addresses a critical security vulnerability in the updatePwd method where new passwords were being stored in plaintext rather than being properly encrypted before storage.

References
https://github.com/cloudexplorer-dev/cloudexplorer-lite/commit/7d4dab60352079953b7be120afe9bd14983ae3bc
https://nvd.nist.gov/vuln/detail/CVE-2023-3423